### PR TITLE
Bug occupation number and multiplicities

### DIFF
--- a/src/include/CosmoInterface/measurements/scalarsingletmeasurer.h
+++ b/src/include/CosmoInterface/measurements/scalarsingletmeasurer.h
@@ -26,6 +26,7 @@ namespace TempLat {
         /* Put public methods here. These should change very little over time. */
         template <typename Model>
         ScalarSingletMeasurer(Model& model, FilesManager& filesManager, const RunParameters<T>& par, bool append):
+        ONMeasurer(par),
         PSType(par.powerSpectrumType)
         {
 
@@ -67,7 +68,7 @@ namespace TempLat {
                     spectraOut(i).save(t,
                             PSMeasurer.powerSpectrum(model.fldS(i)),
                             pow(model.aI, 2 * model.alpha - 6) * PSMeasurer.powerSpectrum(model.piS(i)),
-                            occupationNumber(model, i)
+                            ONMeasurer.occupationNumber(model, i)
                             );
             );
         }
@@ -77,6 +78,8 @@ namespace TempLat {
 
         TempLatVector<MeasurementsSaver<T>> standardOut;
         TempLatVector<SpectrumSaver<T>> spectraOut;
+
+        OccupationNumberMeasurer ONMeasurer;
 
         const int PSType;
     };

--- a/src/include/CosmoInterface/runparameters.h
+++ b/src/include/CosmoInterface/runparameters.h
@@ -51,7 +51,7 @@ namespace TempLat {
                 fixedBackground(expansion ? par.get<bool>("fixedBackground",false) : false), // If true, expansion is given by a fixed background
                 omegaEoS(fixedBackground ? par.get<T>("omegaEoS",1.0 / 3.0) : 0.0), // For fixed background expansion: equation of state
                 H0(fixedBackground ? par.get<T>("H0") : 0.0), // For fixed background expansion: initial Hubble parameter
-                spectraVerbosity(par.get<int>("spectraVerbosity",1)), // Verbosity of spectra files
+                spectraVerbosity(par.get<int>("spectraVerbosity",0)), // Verbosity of spectra files
                 deltaKBin(par.get<double>("deltaKBin",1)), // Bin width of the spectra
                 nBinsSpectra(floor(sqrt(3.0)/2.0 * N / deltaKBin)), // Number of bins in spectra
                 hdf5Spectra(par.get<bool>("hdf5Spectra",false)), // If true, spectra are printed in HDF5 format. If false, printed in txt format.


### PR DESCRIPTION
Corrected a bug in the occupation number: it was unbinned and only the first nBins were stored to files. This also affected the multiplicities displayed in the output.