### PR TITLE
Corrected bug in modelinitializer.h

### DIFF
--- a/src/include/CosmoInterface/initializers/modelinitializer.h
+++ b/src/include/CosmoInterface/initializers/modelinitializer.h
@@ -51,7 +51,7 @@ namespace TempLat {
             if(Model::NCs > 0 or (Model::NSU2Doublet > 0 && Model::NU1 > 0 ) ) U1Initializer::initializeU1(model, fg, rPar.kCutoff);
 
             Averages::setAllAverages(model);
-            if(rPar.expansion) {
+            if(rPar.expansion && !rPar.fixedBackground) {
                 // For consistency, correct the scale factor time-derivative with the fluctuations.
                 // Relevant only for higher order evolvers.
                 auto hubbleLaw =  HubbleConstraint::get(model);


### PR DESCRIPTION
Corrected minor bug when using fixed background expansion. In previous versions, the initial outputted value of a' was wrong when using staggered leapfrog.