### PR TITLE
fixedBackground driftScaleFactor sign mistake?

### DIFF
--- a/src/include/CosmoInterface/evolvers/leapfrog.h
+++ b/src/include/CosmoInterface/evolvers/leapfrog.h
@@ -179,7 +179,7 @@ namespace TempLat {
             model.aIM = model.aI;  // at t
             if(fixedBackground){  // if fixed background, the scale factor is given by the power-law function in fixedbackgroundexpansion.h
                 model.aI = aBackground(tMinust0);
-                model.aSI = aBackground(tMinust0 + model.dt / 2.0);
+                model.aSI = aBackground(tMinust0 - model.dt / 2.0);
             }
             else{    // if self-consistent expansion, the scale factor is evolved with the VV algorithm
                 model.aI += model.dt * model.aDotSI ;  // at t+dt

--- a/src/include/CosmoInterface/evolvers/velocityverlet.h
+++ b/src/include/CosmoInterface/evolvers/velocityverlet.h
@@ -251,7 +251,7 @@ namespace TempLat {
             model.aIM = model.aI;  // at t
             if(fixedBackground){  // if fixed background, the scale factor is given by the power-law function in fixedbackgroundexpansion.h
                 model.aI = aBackground(tMinust0);
-                model.aSI = aBackground(tMinust0 + model.dt / 2.0);
+                model.aSI = aBackground(tMinust0 - model.dt / 2.0);
             }
             else{  // if self-consistent expansion, the scale factor is evolved with the VV algorithm
                 model.aI += model.dt * model.aDotSI * w;


### PR DESCRIPTION
If I understand correctly, `model.aSI` is always half a timestep *behind* `model.aI`.
This is reflected in the `driftScaleFactor` code when self-consistent expansion is on, as well as the `evolve` code in leapfrog and VV.

In the fixedBackground case, CosmoLattice currently sets `model.aSI` at half a timestep *ahead* of `model.aI`. This pull request fixes that.

Thank you for the great simulation suite!